### PR TITLE
Fix Hydra Plugins Module Packaging for Wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,7 @@ authors = [
 readme = "README.md"
 license = "MIT"
 keywords = ["hydra", "plugin", "sweeper", "filter"]
-packages = [
-    { include = "hydra_filter_sweeper" },
-    { include = "filter.py", from = "hydra_plugins" },
-]
+packages = [{ include = "hydra_filter_sweeper" }, { include = "hydra_plugins" }]
 
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This fixes a bug where the `hydra_plugins/filter.py` file was not correctly placed in the `hydra_plugins` directory if the package is installed as a wheel.