### PR TITLE
Optionally Disable Logs for Filtered out Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The configuration is excluded if the expression evaluates to `True`.
 **Parameters**:
 
 - `expr` (_str_): Python expression to evaluate.
-- `fail` (_bool_): Whether to fail if the expression raises an exception. Default is `True`.
+- `fail` (_bool_): Whether to fail if the filter raises an exception. Default is `True`.
 
 **Example Configuration**
 
@@ -101,7 +101,7 @@ The configuration is excluded if the file or directory exists.
 **Parameters**:
 
 - `path` (_str_): Path to the file or directory to check if it exists in the run's directory.
-- `fail` (_bool_): Whether to fail if the expression raises an exception. Default is `True`.
+- `fail` (_bool_): Whether to fail if the filter raises an exception. Default is `True`.
 
 **Example Configuration**
 
@@ -127,7 +127,7 @@ The configuration is excluded if the filter method returns `True`.
 
 - `target` (_str_): Python relative import path to the class.
 - `*` (_Any_): Additional keyword arguments passed to the filter method of the class.
-- `fail` (_bool_): Whether to fail if the expression raises an exception. Default is `True`.
+- `fail` (_bool_): Whether to fail if the filter raises an exception. Default is `True`.
 
 **Example Configuration**
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The configuration is excluded if the expression evaluates to `True`.
 
 - `expr` (_str_): Python expression to evaluate.
 - `fail` (_bool_): Whether to fail if the filter raises an exception. Default is `True`.
+- `log` (_bool_): Whether to log the configuration if the filter evaluates to `True`. Default is `True`.
 
 **Example Configuration**
 
@@ -91,6 +92,7 @@ hydra/sweeper/filters:
   - type: expr
     expr: undefined == 1 and bar == "two"
     fail: false
+    log: false
 ```
 
 ### Exists Filter (`exists`)
@@ -102,6 +104,7 @@ The configuration is excluded if the file or directory exists.
 
 - `path` (_str_): Path to the file or directory to check if it exists in the run's directory.
 - `fail` (_bool_): Whether to fail if the filter raises an exception. Default is `True`.
+- `log` (_bool_): Whether to log the configuration if the filter evaluates to `True`. Default is `True`.
 
 **Example Configuration**
 
@@ -111,6 +114,7 @@ hydra/sweeper/filters:
     path: some_directory/some.file
   - type: exists
     path: some_directory
+    log: false
   - type: exists
     path: some_directory/${some_value}.file
   - type: exists
@@ -128,6 +132,7 @@ The configuration is excluded if the filter method returns `True`.
 - `target` (_str_): Python relative import path to the class.
 - `*` (_Any_): Additional keyword arguments passed to the filter method of the class.
 - `fail` (_bool_): Whether to fail if the filter raises an exception. Default is `True`.
+- `log` (_bool_): Whether to log the configuration if the filter evaluates to `True`. Default is `True`.
 
 **Example Configuration**
 
@@ -136,6 +141,7 @@ hydra/sweeper/filters:
   - type: class
     target: some_filter.SomeFilter
     some_arg: ${some_value}
+    log: false
   - type: class
     target: some_filter.NonExistentFilter
     some_arg: ${some_value}

--- a/hydra_plugins/filter.py
+++ b/hydra_plugins/filter.py
@@ -133,6 +133,7 @@ class FilterSweeper(BasicSweeper):
             except KeyError:
                 raise ValueError(f"Filter type '{filter_type}' not supported")
             fail = f.pop("fail", True)
+            should_log = f.pop("log", True)
             try:
                 should_filter = filter_cls().filter(
                     config=config,
@@ -144,7 +145,8 @@ class FilterSweeper(BasicSweeper):
                     raise ValueError(f"Filter {f} failed: {e}") from e
 
             if should_filter:
-                override = " ".join(override)
-                log.info(f"Filtered: {override} with {filter_type}: {f}")
+                if should_log:
+                    override = " ".join(override)
+                    log.info(f"Filtered: {override} with {filter_type}: {f}")
                 return True
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hydra-filter-sweeper"
-version = "1.0.1"
+version = "1.1.0"
 description = "A Hydra plugin to extend the basic sweeper with customizable filters."
 authors = [
     "Simon Rampp <simon.rampp@tum.de>",

--- a/tests/test_config/with_suppressed_filters.yaml
+++ b/tests/test_config/with_suppressed_filters.yaml
@@ -1,0 +1,19 @@
+defaults:
+  - _self_
+  - override hydra/sweeper: filter
+
+hydra:
+  mode: MULTIRUN
+  sweeper:
+    params:
+      +foo: 1,2,3
+      +bar: one, two, three
+    filters:
+    - type: expr
+      expr: foo == 1 and bar == "two"
+    - type: expr
+      expr: foo == 2 and bar == "three"
+      log: false
+    - type: expr
+      expr: undefined == 1 and bar == "three"
+      fail: false


### PR DESCRIPTION
Currently, if a configuration is filtered out by any filter evaluating to `true`, a log message is created informing the user that the respective configuration will be skipped.
This PR add the option to suppress this log message by explicitly setting `log` to `false` for individual filters.

However, the default behavior is untouched, and the user is still notified about filtered out configurations if `log` is not disabled.

(also bumping version for new release)