### PR TITLE
Allow Nested Configuration Attributes and More Defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ hydra:
 
 Filter configurations based on a Python expression that evaluates to `True` or `False`.
 The context of the expression is the configuration itself.
+All keys in the configuration are added to the attributes list of the
+evaluation model in addition to lists, tuples, and safe function calls
+(e.g., str, int, float, len).
 The configuration is excluded if the expression evaluates to `True`.
 
 **Parameters**:

--- a/hydra_filter_sweeper/filters.py
+++ b/hydra_filter_sweeper/filters.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import os
 
-from evalidate import Expr
+from evalidate import Expr, base_eval_model
 import hydra
 from omegaconf import DictConfig
 
@@ -70,6 +70,10 @@ class FilterExpr(AbstractFilter):
         If the filter condition is met and the configuration should be
         excluded, returns True. Otherwise, returns False.
 
+        All keys in the configuration are added to the attributes list of the
+        evaluation model in addition to lists, tuples, and safe function calls
+        (e.g., str, int, float, len).
+
         Args:
             config (DictConfig): The configuration to be used for filtering.
             directory (str): The directory to be filtered.
@@ -81,7 +85,23 @@ class FilterExpr(AbstractFilter):
         Raises:
             ValueError: If there is an error evaluating the expression.
         """
-        return Expr(expr).eval(config)
+        model = base_eval_model.clone()
+        model.nodes.extend(["List", "Tuple", "Attribute", "Call"])
+        model.allowed_functions.extend(["str", "int", "float", "len"])
+        model.attributes.extend(["startswith", "endswith"])
+
+        keys = set()
+
+        def extract_keys(cfg: DictConfig) -> None:
+            for key, value in cfg.items():
+                if isinstance(value, (dict, DictConfig)):
+                    extract_keys(value)
+                keys.add(key)
+
+        extract_keys(config)
+        model.attributes.extend(keys)
+
+        return Expr(expr, model=model).eval(config)
 
 
 class FilterClass(AbstractFilter):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -73,6 +73,32 @@ class TestFilterExpr:
             DictConfig({"foo": "bar"}), "", "foo == 'baz'"
         )
 
+        # Test cases for evaluating a valid expression with nested variables
+        # and function calls that return True
+        assert filter_expr.filter(
+            DictConfig({"foo": {"bar": "baz"}}), "", "foo.bar == 'baz'"
+        )
+        assert filter_expr.filter(
+            DictConfig({"foo": {"bar": {"baz": "jazz"}}}),
+            "",
+            "foo.bar.baz == 'jazz'",
+        )
+        assert filter_expr.filter(
+            DictConfig({"foo": {"bar": 1}}), "", "str(foo.bar) == '1'"
+        )
+        assert filter_expr.filter(
+            DictConfig({"foo": {"bar": 1}}), "", "foo.bar == int('1')"
+        )
+        assert filter_expr.filter(
+            DictConfig({"foo": {"bar": 1}}), "", "foo.bar in [1,2,3]"
+        )
+        assert filter_expr.filter(
+            DictConfig({"foo": {"bar": "123"}}), "", "foo.bar.startswith('1')"
+        )
+        assert filter_expr.filter(
+            DictConfig({"foo": {"bar": "123"}}), "", "len(foo.bar) == 3"
+        )
+
         # Test case for evaluating an invalid expression with missing variable
         with pytest.raises(EvalException):
             filter_expr.filter(


### PR DESCRIPTION
Closes #7 by supporting `FilterExpr` expressions with:
- all nested attributes of the current configuration, e.g., `model.id == "Model-T"` is now valid
- is in or is not in checks for lists and tuples, e.g., `model.id in ["Model", "Model-T"]` is now valid
- simple function calls (str, int, float, len, starswith, endswith), e.g., `model.id.startswith("Model")` is now valid

We need to dynamically whitelist all keys of the current configuration as we cannot know them in advance.